### PR TITLE
Feat:알람 버튼 생성

### DIFF
--- a/src/components/header/AlarmButton.tsx
+++ b/src/components/header/AlarmButton.tsx
@@ -1,0 +1,18 @@
+import Image from "next/image";
+import { useState } from "react";
+
+const AlarmButton = () => {
+  const [alarm, setAlarm] = useState(false);
+
+  return (
+    <Image
+      src={alarm ? "icon/bookmark-fill-lg.svg" : "icon/bookmark-lg.svg"}
+      width={32}
+      height={32}
+      className="h-6 w-6 pc:h-8 pc:w-8"
+      alt="알림"
+    />
+  );
+};
+
+export default AlarmButton;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -10,6 +10,7 @@ import { useSidebarState } from "@/hooks/useSidebarState";
 import { useEffect, useState } from "react";
 import { useAtom } from "jotai";
 import { isLoggedAtom } from "@/atoms/isLogged";
+import AlarmButton from "./AlarmButton";
 
 const Header = () => {
   const [isLogin, setIsLogin] = useState<boolean | null>(null);
@@ -39,9 +40,12 @@ const Header = () => {
         {isAuthPage ? (
           <AuthPageNavigation />
         ) : isLogin ? (
-          <button onClick={() => setIsOpen(!isOpen)}>
-            <HeaderMenu />
-          </button>
+          <>
+            <AlarmButton />
+            <button onClick={() => setIsOpen(!isOpen)}>
+              <HeaderMenu />
+            </button>
+          </>
         ) : (
           <LoginButton />
         )}


### PR DESCRIPTION
## 🔎 작업 내용
로그인 후, 랜딩 페이지 헤더메뉴 옆에 알림 버튼 생성
알림이 있을 때와 없을 때 이미지에 색을 채워 달리함

## 이미지 첨부
![image](https://github.com/user-attachments/assets/128fbf40-0035-423c-b967-236023638baf)

## 🔧 앞으로의 과제
사장님의 경우, 지원자가 있을 때 알림
지원자의 경우, 지원 결과 여부를 알림
